### PR TITLE
fix : 시간 파싱 오류 해결

### DIFF
--- a/app/src/main/java/com/example/donotlate/core/util/util.kt
+++ b/app/src/main/java/com/example/donotlate/core/util/util.kt
@@ -2,6 +2,9 @@ package com.example.donotlate.core.util
 
 import com.google.firebase.Timestamp
 import java.text.SimpleDateFormat
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
 import java.util.Locale
 
 fun Timestamp.toFormattedString(): String {
@@ -14,4 +17,33 @@ fun Timestamp.toFormattedHMString(): String {
     val sdf = SimpleDateFormat("a hh:mm", Locale.KOREAN)
     val hours = this.toDate()
     return sdf.format(hours)
+}
+
+fun parseTime(timeStr: String): LocalTime? {
+    return try {
+        val trimmedTimeStr = timeStr.trim()
+        // 오전 또는 오후를 분리하여 amPm에 저장
+        val amPm = trimmedTimeStr.substring(0, 2) // "오전" 또는 "오후"
+        // 나머지 시간 부분을 분리하여 time에 저장
+        val time = trimmedTimeStr.substring(3).trim() // "01 : 00"
+        // 시간 문자열을 파싱하기 위한 포맷터 정의
+        val formatter = DateTimeFormatter.ofPattern("HH : mm")
+        // time 문자열을 LocalTime 객체로 변환
+        var localTime = LocalTime.parse(time, formatter)
+
+        // 오전/오후를 처리하여 24시간 형식으로 변환
+        // 오후 상태이며, 시간이 12가 아니면 12시간을 더한다.
+        if (amPm == "오후" && localTime.hour != 12) {
+            localTime = localTime.plusHours(12)
+        }
+        // 오전 상태이며, 12이면 시간을 0으로 설정(자정을 나타냄)
+        else if (amPm == "오전" && localTime.hour == 12) {
+            localTime = localTime.minusHours(12)
+        }
+
+        localTime
+    } catch (e: DateTimeParseException) {
+        e.printStackTrace()
+        null
+    }
 }

--- a/app/src/main/java/com/example/donotlate/feature/mypromise/presentation/model/PromiseModel.kt
+++ b/app/src/main/java/com/example/donotlate/feature/mypromise/presentation/model/PromiseModel.kt
@@ -18,6 +18,7 @@ data class PromiseModel(
     val participants: List<String>,
     val hasArrived: Map<String, Boolean> = mutableMapOf(),
     val participantsNames: Map<String, String> = mutableMapOf()
+
 ) : Parcelable {
     constructor() : this("", "", Timestamp.now(), "", "", "", 0.0, 0.0, "", listOf())
 }

--- a/app/src/main/java/com/example/donotlate/feature/mypromise/presentation/view/MyPromiseListViewModel.kt
+++ b/app/src/main/java/com/example/donotlate/feature/mypromise/presentation/view/MyPromiseListViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.example.donotlate.core.domain.usecase.LoadToMyPromiseListUseCase
 import com.example.donotlate.core.presentation.CurrentUser
+import com.example.donotlate.core.util.parseTime
 import com.example.donotlate.feature.mypromise.presentation.mapper.toPromiseModelList
 import com.example.donotlate.feature.mypromise.presentation.model.PromiseModel
 import kotlinx.coroutines.Job
@@ -14,7 +15,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 class MyPromiseListViewModel(
@@ -45,21 +45,17 @@ class MyPromiseListViewModel(
                     loadToMyPromiseListUseCase(uid).collect {
                         val promiseRooms = it.toPromiseModelList()
                         _promiseRoomList.value = promiseRooms
-                        Log.d("PromiseList", "${_promiseRoomList.value}")
 
-                        // 약속 날짜와 시간을 String -> LocalDate 타입으로 변경하기 위한 포맷팅
+//                         약속 날짜와 시간을 String -> LocalDate 타입으로 변경하기 위한 포맷팅
                         val now = LocalDateTime.now()
                         val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-                        val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
 
                         // 약속 시간과 날짜를 현재 시간과 날짜와 비교한 값
                         // '현재 시간과 날짜'보다 이후의 약속들을 필터링 하기 위한 코드.
                         val upcomingPromise = promiseRooms.filter { rooms ->
                             val promiseDate = LocalDate.parse(rooms.promiseDate, dateFormatter)
-                            val promiseTimeString =
-                                rooms.promiseTime.replace("시", ":").replace("분", "")
-                                    .replace(" ", "")
-                            val promiseTime = LocalTime.parse(promiseTimeString, timeFormatter)
+                            val promiseTime = parseTime(rooms.promiseTime)
+
                             val promiseDateTime = LocalDateTime.of(promiseDate, promiseTime)
                             promiseDateTime.isAfter(now)
                         }
@@ -68,10 +64,8 @@ class MyPromiseListViewModel(
                         val closestPromise = upcomingPromise.minByOrNull {
                             // 파싱을 위한 코드.
                             val promiseDate = LocalDate.parse(it.promiseDate, dateFormatter)
-                            val promiseTimeString =
-                                it.promiseTime.replace("시", ":").replace("분", "").replace(" ", "")
-
-                            val promiseTime = LocalTime.parse(promiseTimeString, timeFormatter)
+                            val promiseTime = parseTime(it.promiseTime)
+                            Log.d("시간확인", "$promiseTime")
 
                             LocalDateTime.of(promiseDate, promiseTime)
                         }
@@ -96,3 +90,4 @@ class MyPromiseListViewModelFactory(
         throw IllegalArgumentException("Unknown ViewModel class")
     }
 }
+

--- a/app/src/main/java/com/example/donotlate/feature/mypromise/presentation/view/MyPromiseRoomFragment.kt
+++ b/app/src/main/java/com/example/donotlate/feature/mypromise/presentation/view/MyPromiseRoomFragment.kt
@@ -10,13 +10,10 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.view.isVisible
-import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
@@ -24,7 +21,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.donotlate.DoNotLateApplication
 import com.example.donotlate.R
 import com.example.donotlate.core.presentation.CurrentUser
-import com.example.donotlate.databinding.DialogRadiobuttonBinding
 import com.example.donotlate.databinding.FragmentMyPromiseRoomBinding
 import com.example.donotlate.feature.directionRoute.presentation.LocationUtils
 import com.example.donotlate.feature.mypromise.presentation.adapter.PromiseMessageAdapter
@@ -178,7 +174,13 @@ class MyPromiseRoomFragment : Fragment() {
             } else {
                 binding.tvRoomPromisePenalty.text = room.penalty
             }
-            binding.tvRoomPromiseParticipants.text = room.participants.toString()
+
+            Log.d("확인해보자", "${room.participantsNames.values}")
+
+            val participantNamesList = room.participantsNames.values.toList()
+            binding.tvRoomPromiseParticipants.text =
+                "참여자: ${participantNamesList.joinToString(", ")}"
+            Log.d("확인해보자1", "${participantNamesList}")
 
             loadToMessageFromFireStore(room.roomId)
         }
@@ -557,7 +559,7 @@ class MyPromiseRoomFragment : Fragment() {
     private fun showNotArriveDialog(userNames: List<String>) {
         dialog = AlertDialog.Builder(requireContext())
             .setTitle("지각자 알림")
-            .setMessage("지각자를 공개합니다! \n ${userNames.joinToString { ", " }}")
+            .setMessage("지각자를 공개합니다!\n${userNames.joinToString(", ")}")
             .create()
         dialog.show()
     }

--- a/app/src/main/java/com/example/donotlate/feature/mypromise/presentation/view/MyPromiseRoomViewModel.kt
+++ b/app/src/main/java/com/example/donotlate/feature/mypromise/presentation/view/MyPromiseRoomViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.example.donotlate.core.domain.usecase.promiseusecase.RemoveParticipantsUseCase
 import com.example.donotlate.core.presentation.CurrentUser
+import com.example.donotlate.core.util.parseTime
 import com.example.donotlate.feature.directionRoute.domain.usecase.GetDirectionsUseCase
 import com.example.donotlate.feature.directionRoute.presentation.DirectionsModel
 import com.example.donotlate.feature.directionRoute.presentation.toModel
@@ -374,22 +375,16 @@ class MyPromiseRoomViewModel(
 
     fun checkArrivalStatus(room: PromiseModel) {
         val now = LocalDateTime.now()
-        Log.d("LocalDateTime", "$now")
 
-        val promiseTime =
-            room.promiseTime.replace("시", ":").replace("분", "").replace(" ", "").trim() // 시간 형식 변환
-
+        val promiseTime = parseTime(room.promiseTime)// 시간 형식 변환
         val promiseDateTime =
             LocalDateTime.parse("${room.promiseDate} $promiseTime", formatter)
-        Log.d("LocalDateTime2", "$promiseDateTime")
+
         if (promiseDateTime.isBefore(now) || promiseDateTime.isEqual(now)) {
             val notArrivedUserIds = room.hasArrived.filter { !it.value }.keys.toList()
-            Log.d("LocalDateTime3", "${notArrivedUserIds}")
             val notArrivedUsers = notArrivedUserIds.map { room.participantsNames[it] ?: "Unknown" }
-            Log.d("LocalDateTime4", "${_lateUsers.value}")
+
             _lateUsers.value = notArrivedUsers
-            Log.d("LocalDateTime5", "${_lateUsers.value}")
-            Log.d("LocalDateTime5", "${lateUsers.value}")
         } else {
             _lateUsers.value = emptyList()
         }

--- a/app/src/main/java/com/example/donotlate/feature/room/presentation/view/RoomStartFragment.kt
+++ b/app/src/main/java/com/example/donotlate/feature/room/presentation/view/RoomStartFragment.kt
@@ -1,6 +1,5 @@
 package com.example.donotlate.feature.room.presentation.view
 
-import android.app.DatePickerDialog
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater


### PR DESCRIPTION
1. promiseTime 정보 양식 변경으로 인한 파싱오류
- 기존 hh시 mm분 -> 오전(또는 오후) hh시 mm분으로 변경되면서 기존 파싱 코드가 작동을 안하는 오류 발생,
- 파싱 코드 변경으로 오류 해결

//

Ps.
PromiseRoomModel에 
promiseDateTime이라는 필드를 설정해서, 새로이 값을 할당(Unix 코드 또는 LocalTime -> toString하여 String 형 변환)하고,
이를 활용해서 사용하고자 하였으나, 타임피커에서 시간을 선택할 때, 현재 설정되어있는 시간 표기로 데이터가 저장되어, 
이를 저장하기가 용이하지 않아 시간이 걸릴 것이라 예상.
-> 파싱 코드를 강화하여 이를 통해 임시적으로 해결. 